### PR TITLE
Qt6 migration UI refactor + submodule update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.user
+CMakePresets.json
+build
+.clangd
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(CavalierContoursDev)
 
 SET(CAVC_HEADER_ONLY ON CACHE BOOL "using headers only")

--- a/CavalierContoursDev.pro
+++ b/CavalierContoursDev.pro
@@ -2,6 +2,10 @@ QT += core quick
 
 CONFIG += c++14
 
+lessThan(QT_MAJOR_VERSION, 6) {
+    error("This project requires Qt 6 or newer.")
+}
+
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0

--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 This is a Qt project for development work on the [CavalierContours project](https://github.com/jbuckmccready/CavalierContours). It has an interactive UI app for exploring and testing the algorithm as well as any benchmarks/tests. The project uses a submodule for tracking the main CavalierContours project.
 
 # Requirements to Build and Run
-- CMake (tested with CMake 3.15.3)
-- Qt 5.13 or later (tested with Qt 13.1 and Qt 14.0)
+- CMake 3.16 or later
+- Qt 6.2 or later (tested with Qt 6.9 and Qt 6.10)
 - C++14 compatible compiler (tested with GCC 7.3.0 64 bit and MSVC 2019)
+- git initialized: `git submodule update --init --recursive`
 
 # Basic Getting Started on Windows
 1. Install the latest CMake (can be found [here](https://cmake.org/download/))
-2. Install Qt and the MinGW 7.3.0 tools via the Qt Online Installer (can be found [here](https://www.qt.io/download), select the "Downloads for open source users")
+2. Install Qt 6 and either the MSVC or MinGW tools via the Qt Online Installer (can be found [here](https://www.qt.io/download), select the "Downloads for open source users")
 3. Open Qt Creator, go to Tools->Options menu
 4. Click on "Kits" on the left, then click on the "CMake" tab
 5. If CMake was not auto detected (shown under "Auto-detected") then click "Add" on the right and set the "Path" parameter to `C:\Program Files (x86)\CMake\bin\cmake.exe` or wherever you installed CMake and save the settings
 6. Clone this repository including submodules `git clone --recursive https://github.com/jbuckmccready/CavalierContoursDev.git`
 7. Ensure git is in your `PATH` environment variable (required when running CMake to clone and download clipper and google test for benchmarks and tests)
-8. Open the root CMakeLists.txt in Qt Creator and select the MinGW 7.3.0 kit
-9. Click the Kits button in the lower left of Qt Creator (has a computer icon) and select MinGW->Debug->InteractiveUI
+8. Open the root CMakeLists.txt in Qt Creator and select a Qt 6 kit
+9. Click the Kits button in the lower left of Qt Creator (has a computer icon) and select your kit -> Debug -> InteractiveUI
 10. Click the Run button in the lower left, the interactive ui application should run
 
 # Changing the Test Polyline

--- a/interactiveui/CMakeLists.txt
+++ b/interactiveui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.16)
 
 project(InteractiveUI LANGUAGES CXX)
 
@@ -11,7 +11,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 
 add_executable(InteractiveUI
   main.cpp
@@ -36,4 +36,4 @@ target_link_libraries(InteractiveUI
 target_compile_definitions(InteractiveUI
   PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
 target_link_libraries(InteractiveUI
-  PRIVATE Qt5::Core Qt5::Quick)
+  PRIVATE Qt6::Core Qt6::Quick)

--- a/interactiveui/GeometrySceneView.qml
+++ b/interactiveui/GeometrySceneView.qml
@@ -2,111 +2,112 @@ import QtQuick 2.13
 import Polyline 1.0
 
 Rectangle {
-  id: rect
-  clip: true
-  default property alias content: plineSceneItem.children
-  Rectangle {
-    id: plineSceneItem
-    width: 20000
-    height: 20000
-    // initially center (0,0)
-    x: (1680-300)/2 - 10000
-    y: 1050/2 - 10000
-    border.width: 1/scaler.xScale
-    border.color: "blue"
-
-    transform: Scale {
-      id: scaler
-      origin.x: pinchArea.m_x2
-      origin.y: pinchArea.m_y2
-      xScale: pinchArea.m_zoom2
-      yScale: pinchArea.m_zoom2
-    }
-
-    PinchArea {
-      id: pinchArea
-      anchors.fill: parent
-      property real m_x1: 0
-      property real m_y1: 0
-      property real m_y2: 0
-      property real m_x2: 0
-      property real m_zoom1: 1
-      property real m_zoom2: 1
-      property real m_max: 10
-      property real m_min: 0.05
-
-      onPinchStarted: {
-        m_x1 = scaler.origin.x
-        m_y1 = scaler.origin.y
-        m_x2 = pinch.startCenter.x
-        m_y2 = pinch.startCenter.y
-        plineSceneItem.x = plineSceneItem.x + (pinchArea.m_x1-pinchArea.m_x2)*(1-pinchArea.m_zoom1)
-        plineSceneItem.y = plineSceneItem.y + (pinchArea.m_y1-pinchArea.m_y2)*(1-pinchArea.m_zoom1)
-      }
-      onPinchUpdated: {
-        m_zoom1 = scaler.xScale
-        var dz = pinch.scale-pinch.previousScale
-        var newZoom = m_zoom1+dz
-        if (newZoom <= m_max && newZoom >= m_min) {
-          m_zoom2 = newZoom
-        }
-      }
-
-      MouseArea {
-        id: dragArea
-        hoverEnabled: true
-        anchors.fill: parent
-        drag.target: plineSceneItem
-        drag.filterChildren: true
-        onWheel: {
-          pinchArea.m_x1 = scaler.origin.x
-          pinchArea.m_y1 = scaler.origin.y
-          pinchArea.m_zoom1 = scaler.xScale
-
-          pinchArea.m_x2 = mouseX
-          pinchArea.m_y2 = mouseY
-
-          var newZoom
-          if (wheel.angleDelta.y > 0) {
-            newZoom = pinchArea.m_zoom1+0.15
-            if (newZoom <= pinchArea.m_max) {
-              pinchArea.m_zoom2 = newZoom
-            } else {
-              pinchArea.m_zoom2 = pinchArea.m_max
-            }
-          } else {
-            newZoom = pinchArea.m_zoom1-0.15
-            if (newZoom >= pinchArea.m_min) {
-              pinchArea.m_zoom2 = newZoom
-            } else {
-              pinchArea.m_zoom2 = pinchArea.m_min
-            }
-          }
-          plineSceneItem.x = plineSceneItem.x + (pinchArea.m_x1-pinchArea.m_x2)*(1-pinchArea.m_zoom1)
-          plineSceneItem.y = plineSceneItem.y + (pinchArea.m_y1-pinchArea.m_y2)*(1-pinchArea.m_zoom1)
-        }
-        MouseArea {
-          anchors.fill: parent
-        }
-      }
-    }
-
+    id: rect
+    color: "white"
+    clip: true
+    default property alias content: plineSceneItem.children
 
     Rectangle {
-      id: horizontalAxis
-      x: parent.width / 2
-      height: parent.height
-      color: "black"
-      width: 1 / pinchArea.m_zoom2
-    }
-    Rectangle {
-      id: verticalAxis
-      y: parent.width / 2
-      width: parent.width
-      color: "black"
-      height: 1 / pinchArea.m_zoom2
-    }
+        id: plineSceneItem
+        property real sceneSize: 20000
 
-  }
+        width: sceneSize
+        height: sceneSize
+        // Initially center (0,0) based on current viewport size.
+        x: (rect.width - width) / 2
+        y: (rect.height - height) / 2
+        border.width: 1 / scaler.xScale
+        border.color: "blue"
 
+        transform: Scale {
+            id: scaler
+            origin.x: pinchArea.m_x2
+            origin.y: pinchArea.m_y2
+            xScale: pinchArea.m_zoom2
+            yScale: pinchArea.m_zoom2
+        }
+
+        PinchArea {
+            id: pinchArea
+            anchors.fill: parent
+            property real m_x1: 0
+            property real m_y1: 0
+            property real m_y2: 0
+            property real m_x2: 0
+            property real m_zoom1: 1
+            property real m_zoom2: 1
+            property real m_max: 10
+            property real m_min: 0.05
+
+            onPinchStarted: {
+                m_x1 = scaler.origin.x;
+                m_y1 = scaler.origin.y;
+                m_x2 = pinch.startCenter.x;
+                m_y2 = pinch.startCenter.y;
+                plineSceneItem.x = plineSceneItem.x + (pinchArea.m_x1 - pinchArea.m_x2) * (1 - pinchArea.m_zoom1);
+                plineSceneItem.y = plineSceneItem.y + (pinchArea.m_y1 - pinchArea.m_y2) * (1 - pinchArea.m_zoom1);
+            }
+            onPinchUpdated: {
+                m_zoom1 = scaler.xScale;
+                var dz = pinch.scale - pinch.previousScale;
+                var newZoom = m_zoom1 + dz;
+                if (newZoom <= m_max && newZoom >= m_min) {
+                    m_zoom2 = newZoom;
+                }
+            }
+
+            MouseArea {
+                id: dragArea
+                hoverEnabled: true
+                anchors.fill: parent
+                drag.target: plineSceneItem
+                drag.filterChildren: true
+                onWheel: {
+                    pinchArea.m_x1 = scaler.origin.x;
+                    pinchArea.m_y1 = scaler.origin.y;
+                    pinchArea.m_zoom1 = scaler.xScale;
+
+                    pinchArea.m_x2 = mouseX;
+                    pinchArea.m_y2 = mouseY;
+
+                    var newZoom;
+                    if (wheel.angleDelta.y > 0) {
+                        newZoom = pinchArea.m_zoom1 + 0.15;
+                        if (newZoom <= pinchArea.m_max) {
+                            pinchArea.m_zoom2 = newZoom;
+                        } else {
+                            pinchArea.m_zoom2 = pinchArea.m_max;
+                        }
+                    } else {
+                        newZoom = pinchArea.m_zoom1 - 0.15;
+                        if (newZoom >= pinchArea.m_min) {
+                            pinchArea.m_zoom2 = newZoom;
+                        } else {
+                            pinchArea.m_zoom2 = pinchArea.m_min;
+                        }
+                    }
+                    plineSceneItem.x = plineSceneItem.x + (pinchArea.m_x1 - pinchArea.m_x2) * (1 - pinchArea.m_zoom1);
+                    plineSceneItem.y = plineSceneItem.y + (pinchArea.m_y1 - pinchArea.m_y2) * (1 - pinchArea.m_zoom1);
+                }
+                MouseArea {
+                    anchors.fill: parent
+                }
+            }
+        }
+
+        Rectangle {
+            id: horizontalAxis
+            x: parent.width / 2
+            height: parent.height
+            color: "black"
+            width: 1 / pinchArea.m_zoom2
+        }
+        Rectangle {
+            id: verticalAxis
+            y: parent.height / 2
+            width: parent.width
+            color: "black"
+            height: 1 / pinchArea.m_zoom2
+        }
+    }
 }

--- a/interactiveui/HilbertCurveScene.qml
+++ b/interactiveui/HilbertCurveScene.qml
@@ -4,290 +4,311 @@ import QtQuick.Layouts 1.13
 import DemoFuncs 1.0
 
 SplitView {
-  ScrollView {
-    clip: true
-    SplitView.fillWidth: true
-    contentWidth: hilbertVisual.implicitWidth * scale.xScale
-    contentHeight: hilbertVisual.implicitHeight * scale.xScale
-    Column {
-      id: hilbertVisual
-      spacing: 0
-      transform: Scale {
-        id: scale
-        xScale: scaleSlider.value * 8/hilbertGrid.gridDim
-        yScale: xScale
-      }
-      Grid {
-        id: hilbertGrid
-        property int gridDim: 8
-        rows: gridDim
-        columns: gridDim
+    id: root
+    property bool colorCellsEnabled: true
 
-
-        function scaleForHilbert(minValue, totalExtent, value) {
-          const hilbertMax = (1 << 16) - 1;
-          return Math.floor(hilbertMax * (value - minValue) / totalExtent);
-        }
-
-        function hilbertIndex(xIdx, yIdx) {
-          var hx = scaleForHilbert(0, hilbertGrid.gridDim - 1, xIdx);
-          var hy = scaleForHilbert(0, hilbertGrid.gridDim - 1, yIdx);
-          return DemoFuncs.hilbertXYToIndex(hx, hy);
-        }
-
-        ListModel {
-          id: hilbertGridModel
-        }
-        ListModel {
-          id: hilbertRowModel
-        }
-
-
-        function toLinearIndex(xIdx, yIdx) {
-          return xIdx + yIdx * columns;
-        }
-
-        function direction(fromCell, toCell) {
-          if (fromCell === undefined || toCell === undefined) {
-            return "";
-          }
-
-          if (fromCell.xIndex === toCell.xIndex) {
-            if (fromCell.yIndex - 1 === toCell.yIndex) {
-              return "up";
+    ScrollView {
+        clip: true
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        contentWidth: hilbertVisual.implicitWidth * scale.xScale
+        contentHeight: hilbertVisual.implicitHeight * scale.xScale
+        Column {
+            id: hilbertVisual
+            spacing: 0
+            transform: Scale {
+                id: scale
+                xScale: scaleSlider.value * 8 / hilbertGrid.gridDim
+                yScale: xScale
             }
-            if (fromCell.yIndex === toCell.yIndex - 1) {
-              return "down";
+            Grid {
+                id: hilbertGrid
+                property int gridDim: 8
+                rows: gridDim
+                columns: gridDim
+
+                function scaleForHilbert(minValue, totalExtent, value) {
+                    const hilbertMax = (1 << 16) - 1;
+                    return Math.floor(hilbertMax * (value - minValue) / totalExtent);
+                }
+
+                function hilbertIndex(xIdx, yIdx) {
+                    var hx = scaleForHilbert(0, hilbertGrid.gridDim - 1, xIdx);
+                    var hy = scaleForHilbert(0, hilbertGrid.gridDim - 1, yIdx);
+                    return DemoFuncs.hilbertXYToIndex(hx, hy);
+                }
+
+                ListModel {
+                    id: hilbertGridModel
+                }
+                ListModel {
+                    id: hilbertRowModel
+                }
+
+                function toLinearIndex(xIdx, yIdx) {
+                    return xIdx + yIdx * columns;
+                }
+
+                function direction(fromCell, toCell) {
+                    if (fromCell === undefined || toCell === undefined) {
+                        return "";
+                    }
+
+                    if (fromCell.xIndex === toCell.xIndex) {
+                        if (fromCell.yIndex - 1 === toCell.yIndex) {
+                            return "up";
+                        }
+                        if (fromCell.yIndex === toCell.yIndex - 1) {
+                            return "down";
+                        }
+                    } else if (fromCell.yIndex === toCell.yIndex) {
+                        if (fromCell.xIndex - 1 === toCell.xIndex) {
+                            return "left";
+                        }
+
+                        if (fromCell.xIndex === toCell.xIndex - 1) {
+                            return "right";
+                        }
+                    }
+
+                    return "";
+                }
+
+                function refreshModels() {
+                    var hModel = [];
+                    for (var yIdx = 0; yIdx < gridDim; ++yIdx) {
+                        for (var xIdx = 0; xIdx < gridDim; ++xIdx) {
+                            var hIdx = hilbertIndex(xIdx, yIdx);
+                            hModel.push({
+                                xIndex: xIdx,
+                                yIndex: yIdx,
+                                hIndex: hIdx,
+                                scaledHIndex: hIdx / 4294967295.0,
+                                prevNeighbor: -1,
+                                nextNeighbor: -1
+                            });
+                        }
+                    }
+
+                    var copy = hModel.slice();
+                    copy.sort(function (a, b) {
+                        return a.hIndex - b.hIndex;
+                    });
+                    copy[0].nextNeighbor = 1;
+                    for (var i = 1; i < copy.length - 1; ++i) {
+                        copy[i].nextNeighbor = i + 1;
+                        copy[i].prevNeighbor = i - 1;
+                    }
+
+                    copy[copy.length - 1].prevNeighbor = copy.length - 2;
+
+                    hilbertRowModel.clear();
+                    hilbertGridModel.clear();
+
+                    for (var k = 0; k < copy.length; ++k) {
+                        var c = copy[k];
+                        c.prevDir = direction(c, copy[c.prevNeighbor]);
+                        c.nextDir = direction(c, copy[c.nextNeighbor]);
+                        hilbertRowModel.append(c);
+                    }
+
+                    for (var j = 0; j < hModel.length; ++j) {
+                        hilbertGridModel.append(hModel[j]);
+                    }
+                }
+
+                onGridDimChanged: {
+                    refreshModels();
+                }
+
+                Component.onCompleted: {
+                    refreshModels();
+                }
+
+                Repeater {
+                    model: hilbertGridModel
+                    Rectangle {
+                        id: cell
+                        width: 100
+                        height: 100
+                        border.width: showGridLinesCheckBox.checked ? 1 : 0
+                        color: root.colorCellsEnabled ? hilbertGrid.colorMap(model.scaledHIndex) : "white"
+
+                        Item {
+                            id: connectors
+                            anchors.fill: parent
+                            property int connectorWidth: 8
+
+                            Rectangle {
+                                color: "grey"
+                                property string direction: model.prevDir
+
+                                x: direction === "left" ? 0 : parent.width / 2
+                                y: direction === "up" ? 0 : parent.height / 2
+                                width: connectors.connectorWidth + (direction === "left" || direction === "right" ? parent.width / 2 : 0)
+                                height: connectors.connectorWidth + (direction === "up" || direction === "down" ? parent.height / 2 : 0)
+                            }
+
+                            Rectangle {
+                                color: "grey"
+                                property string direction: model.nextDir
+
+                                x: direction === "left" ? 0 : parent.width / 2
+                                y: direction === "up" ? 0 : parent.height / 2
+                                width: connectors.connectorWidth + (direction === "left" || direction === "right" ? parent.width / 2 : 0)
+                                height: connectors.connectorWidth + (direction === "up" || direction === "down" ? parent.height / 2 : 0)
+                            }
+
+                            Text {
+                                anchors.fill: parent
+                                visible: showWeightingsCheckBox.checked
+                                verticalAlignment: Text.AlignVCenter
+                                horizontalAlignment: Text.AlignHCenter
+                                font.pointSize: 20
+                                text: model.scaledHIndex.toFixed(2)
+                            }
+                        }
+                    }
+                }
+
+                function colorMap(value) {
+                    if (value < 0.2) {
+                        return "#ffa600";
+                    }
+
+                    if (value < 0.4) {
+                        return "#ff6361";
+                    }
+
+                    if (value < 0.6) {
+                        return "#bc5090";
+                    }
+
+                    if (value < 0.8) {
+                        return "#58508d";
+                    }
+
+                    if (value <= 1.0) {
+                        return "#003f5c";
+                    }
+                }
             }
-          } else if (fromCell.yIndex === toCell.yIndex)  {
-            if (fromCell.xIndex - 1 === toCell.xIndex) {
-              return "left";
+
+            Flow {
+                anchors.left: hilbertGrid.left
+                anchors.right: hilbertGrid.right
+                spacing: 0
+                padding: 0
+                Repeater {
+                    model: hilbertRowModel
+                    Rectangle {
+                        id: linearCell
+                        width: 50
+                        height: 60
+                        border.width: 1
+                        color: root.colorCellsEnabled ? hilbertGrid.colorMap(model.scaledHIndex) : "white"
+                        Text {
+                            anchors.fill: parent
+                            visible: showWeightingsCheckBox.checked
+                            verticalAlignment: Text.AlignVCenter
+                            horizontalAlignment: Text.AlignHCenter
+                            text: model.scaledHIndex.toFixed(2)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ScrollView {
+        id: controlPanel
+        clip: true
+        SplitView.minimumWidth: 270
+        SplitView.preferredWidth: 320
+        SplitView.maximumWidth: 440
+        SplitView.fillHeight: true
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        contentWidth: controlColumn.width
+        contentHeight: controlColumn.implicitHeight
+
+        Column {
+            id: controlColumn
+            width: Math.max(1, controlPanel.availableWidth)
+            spacing: 8
+
+            GroupBox {
+                width: controlColumn.width
+                title: "Description"
+
+                Text {
+                    width: parent.width
+                    wrapMode: Text.Wrap
+                    text: "Draws the Hilbert space filling curve. Note only when the grid dimension is a power of 2 " + "(2, 4, 8, etc.) does the curve connect properly. This is because the hilbert values are " + "mapped to [0 -> 2^32 - 1]."
+                }
             }
 
-            if (fromCell.xIndex === toCell.xIndex - 1) {
-              return "right";
+            GroupBox {
+                width: controlColumn.width
+                title: "Scale = " + Math.round(scaleSlider.value * 100) + "%"
+
+                Slider {
+                    id: scaleSlider
+                    width: parent.width
+                    from: 0.2
+                    to: 3
+                    stepSize: 0.1
+                    value: 1.0
+                }
             }
-          }
 
-          return "";
-        }
+            GroupBox {
+                width: controlColumn.width
+                title: "Grid Dimension = " + hilbertGrid.gridDim
 
-        function refreshModels() {
-          var hModel = [];
-          for(var yIdx = 0; yIdx < gridDim; ++yIdx) {
-            for (var xIdx = 0; xIdx < gridDim; ++xIdx) {
-              var hIdx = hilbertIndex(xIdx, yIdx);
-              hModel.push({
-                            xIndex: xIdx,
-                            yIndex: yIdx,
-                            hIndex: hIdx,
-                            scaledHIndex: hIdx / 4294967295.0,
-                            prevNeighbor: -1,
-                            nextNeighbor: -1
-                          });
+                Slider {
+                    width: parent.width
+                    from: 2
+                    to: 16
+                    stepSize: 1
+                    value: hilbertGrid.gridDim
+                    onValueChanged: {
+                        hilbertGrid.gridDim = value;
+                    }
+                }
             }
-          }
 
-          var copy = hModel.slice();
-          copy.sort(function (a, b) { return a.hIndex - b.hIndex});
-          copy[0].nextNeighbor = 1;
-          for (var i = 1; i < copy.length - 1; ++i) {
-            copy[i].nextNeighbor = i + 1;
-            copy[i].prevNeighbor = i - 1;
-          }
-
-          copy[copy.length - 1].prevNeighbor = copy.length - 2;
-
-          hilbertRowModel.clear();
-          hilbertGridModel.clear();
-
-          for (var k = 0; k < copy.length; ++k) {
-            var c = copy[k];
-            c.prevDir = direction(c, copy[c.prevNeighbor]);
-            c.nextDir = direction(c, copy[c.nextNeighbor]);
-            hilbertRowModel.append(c);
-          }
-
-          for (var j = 0; j < hModel.length; ++j) {
-            hilbertGridModel.append(hModel[j]);
-          }
-        }
-
-        onGridDimChanged: {
-          refreshModels();
-        }
-
-        Component.onCompleted: {
-          refreshModels();
-        }
-
-        Repeater {
-          model: hilbertGridModel
-          Rectangle {
-            id: cell
-            width: 100
-            height: 100
-            border.width: showGridLinesCheckBox.checked ? 1 : 0
-            color: colorCellsCheckBox.checked ? hilbertGrid.colorMap(model.scaledHIndex) : "white"
-
-            Item {
-              id: connectors
-              anchors.fill: parent
-              property int connectorWidth: 8
-
-              Rectangle {
-                color: "grey"
-                property string direction: model.prevDir
-
-                x: direction === "left" ? 0 : parent.width / 2
-                y: direction === "up" ? 0 : parent.height / 2
-                width: connectors.connectorWidth + (direction === "left" || direction === "right" ? parent.width / 2 : 0)
-                height: connectors.connectorWidth + (direction ===  "up" || direction === "down" ? parent.height / 2 : 0)
-              }
-
-              Rectangle {
-                color: "grey"
-                property string direction: model.nextDir
-
-                x: direction === "left" ? 0 : parent.width / 2
-                y: direction === "up" ? 0 : parent.height / 2
-                width: connectors.connectorWidth + (direction === "left" || direction === "right" ? parent.width / 2 : 0)
-                height: connectors.connectorWidth + (direction ===  "up" || direction === "down" ? parent.height / 2 : 0)
-              }
-
-              Text {
-                anchors.fill: parent
-                visible: showWeightingsCheckBox.checked
-                verticalAlignment: Text.AlignVCenter
-                horizontalAlignment: Text.AlignHCenter
-                font.pointSize: 20
-                text: model.scaledHIndex.toFixed(2)
-              }
-
+            CheckBox {
+                id: showWeightingsCheckBox
+                width: controlColumn.width
+                text: "Show Weightings"
+                checked: true
             }
-          }
-        }
 
-
-        function colorMap(value) {
-          if (value < 0.2) {
-            return "#ffa600";
-          }
-
-          if (value < 0.4) {
-            return "#ff6361";
-          }
-
-          if (value < 0.6) {
-            return "#bc5090";
-          }
-
-          if (value < 0.8) {
-            return "#58508d";
-          }
-
-          if (value <= 1.0) {
-            return "#003f5c";
-          }
-
-        }
-      }
-
-      Flow {
-        anchors.left: hilbertGrid.left
-        anchors.right: hilbertGrid.right
-        spacing: 0
-        padding: 0
-        Repeater {
-          model: hilbertRowModel
-          Rectangle {
-            id: linearCell
-            width: 50
-            height: 60
-            border.width: 1
-            color: colorCellsCheckBox.checked ? hilbertGrid.colorMap(model.scaledHIndex) : "white"
-            Text {
-              anchors.fill: parent
-              visible: showWeightingsCheckBox.checked
-              verticalAlignment: Text.AlignVCenter
-              horizontalAlignment: Text.AlignHCenter
-              text: model.scaledHIndex.toFixed(2)
+            CheckBox {
+                id: colorCellsCheckBox
+                width: controlColumn.width
+                text: "Color Cells"
+                checked: root.colorCellsEnabled
+                onToggled: {
+                    root.colorCellsEnabled = checked;
+                }
             }
-          }
+
+            CheckBox {
+                id: showGridLinesCheckBox
+                width: controlColumn.width
+                text: "Show Grid Lines"
+                checked: false
+            }
+
+            CheckBox {
+                // unknown why the last checkbox is not able to show completely
+                id: dummyCheckBox
+                visible: false
+                width: controlColumn.width
+                text: "Dummy"
+                checked: false
+            }
         }
-
-      }
-
     }
-  }
-
-  ColumnLayout {
-    anchors.topMargin: 5
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    SplitView.preferredWidth: 300
-
-    GroupBox {
-      Layout.fillWidth: true
-      title: "Description"
-      Text {
-        wrapMode: Text.Wrap
-        anchors.fill: parent
-        text: "Draws the Hilbert space filling curve. Note only when the grid dimension is a power of 2 " +
-              "(2, 4, 8, etc.) does the curve connect properly. This is because the hilbert values are " +
-              "mapped to [0 -> 2^32 - 1]."
-      }
-    }
-
-    GroupBox {
-      leftInset: 5
-      title: "Scale = " + Math.round(scaleSlider.value * 100) + "%"
-      Slider {
-        id: scaleSlider
-        from: 0.2
-        to: 3
-        stepSize: 0.1
-        value: 1.0
-      }
-    }
-
-    GroupBox {
-      leftInset: 5
-      title: "Grid Dimension = " + hilbertGrid.gridDim
-      Slider {
-        from: 2
-        to: 16
-        stepSize: 1
-        value: hilbertGrid.gridDim
-        onValueChanged: {
-          hilbertGrid.gridDim = value;
-        }
-      }
-    }
-
-    CheckBox {
-      id: showWeightingsCheckBox
-      text: "Show Weightings"
-      checked: true
-    }
-
-    CheckBox {
-      id: showGridLinesCheckBox
-      text: "Show Grid Lines"
-      checked: false
-    }
-
-    CheckBox {
-      id: colorCellsCheckBox
-      text: "Color Cells"
-      checked: true
-    }
-
-    Item {
-      Layout.fillHeight: true
-    }
-  }
 }
-
-
-

--- a/interactiveui/PlineCombineScene.qml
+++ b/interactiveui/PlineCombineScene.qml
@@ -4,80 +4,101 @@ import QtQuick.Layouts 1.13
 import Polyline 1.0
 
 SplitView {
-  GeometrySceneView {
-    SplitView.fillWidth: true
-    PlineCombineAlgorithmView {
-      id: algorithmView
-      anchors.fill: parent
-      plineCombineMode: combineModeComboBox.currentIndex
-    }
-  }
+    GeometrySceneView {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        SplitView.minimumWidth: 320
 
-  ColumnLayout {
-    anchors.topMargin: 5
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    SplitView.preferredWidth: 300
-
-    CheckBox {
-      text: "Show Vertexes"
-      checked: algorithmView.showVertexes
-      onCheckedChanged: {
-        algorithmView.showVertexes = checked;
-      }
-    }
-
-    CheckBox {
-      text: "Show Intersects"
-      checked: algorithmView.showIntersects
-      onCheckedChanged: {
-        algorithmView.showIntersects = checked;
-      }
-    }
-
-    GroupBox {
-      title: "Combine Mode"
-      leftInset: 5
-      ColumnLayout {
-        ComboBox {
-          id: combineModeComboBox
-          leftInset: 5
-          model: ["None", "Union", "Exclude", "Intersect", "XOR", "Coincident Slices"]
-          implicitWidth: 200
+        PlineCombineAlgorithmView {
+            id: algorithmView
+            anchors.fill: parent
+            plineCombineMode: combineModeComboBox.currentIndex
         }
-        CheckBox {
-          text: "Flip Arg Order"
-          checked: algorithmView.flipArgOrder
-          onCheckedChanged: {
-            algorithmView.flipArgOrder = checked;
-          }
-        }
-      }
     }
 
+    ScrollView {
+        id: controlPanel
+        clip: true
+        contentWidth: availableWidth
+        SplitView.minimumWidth: 270
+        SplitView.preferredWidth: 320
+        SplitView.maximumWidth: 440
+        SplitView.fillHeight: true
 
-    GroupBox {
-      title: "Winding Number"
-      leftInset: 5
-      ColumnLayout {
-        CheckBox {
-          text: "Show Test Point"
-          checked: algorithmView.showWindingNumberPoint
-          onCheckedChanged: {
-            algorithmView.showWindingNumberPoint = checked;
-          }
+        ColumnLayout {
+            width: controlPanel.availableWidth
+            spacing: 8
+
+            CheckBox {
+                Layout.fillWidth: true
+                text: "Show Vertexes"
+                checked: algorithmView.showVertexes
+                onCheckedChanged: {
+                    algorithmView.showVertexes = checked;
+                }
+            }
+
+            CheckBox {
+                Layout.fillWidth: true
+                text: "Show Intersects"
+                checked: algorithmView.showIntersects
+                onCheckedChanged: {
+                    algorithmView.showIntersects = checked;
+                }
+            }
+
+            GroupBox {
+                title: "Combine Mode"
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    anchors.fill: parent
+
+                    ComboBox {
+                        id: combineModeComboBox
+                        Layout.fillWidth: true
+                        model: ["None", "Union", "Exclude", "Intersect", "XOR", "Coincident Slices"]
+                    }
+
+                    CheckBox {
+                        Layout.fillWidth: true
+                        text: "Flip Arg Order"
+                        checked: algorithmView.flipArgOrder
+                        onCheckedChanged: {
+                            algorithmView.flipArgOrder = checked;
+                        }
+                    }
+                }
+            }
+
+            GroupBox {
+                title: "Winding Number"
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    anchors.fill: parent
+
+                    CheckBox {
+                        Layout.fillWidth: true
+                        text: "Show Test Point"
+                        checked: algorithmView.showWindingNumberPoint
+                        onCheckedChanged: {
+                            algorithmView.showWindingNumberPoint = checked;
+                        }
+                    }
+
+                    Text {
+                        id: windingNumberText
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                        text: "Winding Number: " + algorithmView.windingNumber
+                    }
+                }
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
         }
-
-        Text {
-          id: windingNumberText
-          leftPadding: 6
-          text: "Winding Number: " + algorithmView.windingNumber
-        }
-      }
     }
-
-    Item {
-      Layout.fillHeight: true
-    }
-  }
 }

--- a/interactiveui/PlineOffsetIslandsScene.qml
+++ b/interactiveui/PlineOffsetIslandsScene.qml
@@ -4,100 +4,128 @@ import QtQuick.Layouts 1.13
 import Polyline 1.0
 
 SplitView {
-  GeometrySceneView {
-    SplitView.fillWidth: true
-    PlineOffsetIslandsAlgorithmView {
-      id: algorithmView
-      anchors.fill: parent
+    GeometrySceneView {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        SplitView.minimumWidth: 320
+
+        PlineOffsetIslandsAlgorithmView {
+            id: algorithmView
+            anchors.fill: parent
+        }
     }
-  }
 
-  ColumnLayout {
-    anchors.topMargin: 5
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    SplitView.preferredWidth: 300
+    ScrollView {
+        id: controlPanel
+        clip: true
+        contentWidth: availableWidth
+        SplitView.minimumWidth: 270
+        SplitView.preferredWidth: 320
+        SplitView.maximumWidth: 440
+        SplitView.fillHeight: true
 
-    GroupBox {
-      title: "Offset"
-      leftInset: 5
-      ColumnLayout {
-        Item {
-          id: offsetItem
-          implicitWidth: offsetSlider.implicitWidth
-          implicitHeight: offsetTextField.implicitHeight + offsetSlider.implicitHeight + minText.implicitHeight
-          TextField {
-            id: offsetTextField
-            anchors.top: offsetItem.top
-            validator: DoubleValidator { bottom: offsetSlider.from; top: offsetSlider.to }
-            text: if (!focus) { offsetSlider.value } else ""
-            onTextChanged: {
-              let f = parseFloat(text);
-              if (isNaN(f)) {
-                return;
-              }
+        ColumnLayout {
+            width: controlPanel.availableWidth
+            spacing: 8
 
-              offsetSlider.value = f;
+            GroupBox {
+                title: "Offset"
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    anchors.fill: parent
+
+                    Item {
+                        id: offsetItem
+                        Layout.fillWidth: true
+                        implicitHeight: offsetTextField.implicitHeight + offsetSlider.implicitHeight + minText.implicitHeight
+
+                        TextField {
+                            id: offsetTextField
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            validator: DoubleValidator {
+                                bottom: offsetSlider.from
+                                top: offsetSlider.to
+                            }
+                            text: if (!focus) {
+                                offsetSlider.value;
+                            } else
+                                ""
+                            onTextChanged: {
+                                let f = parseFloat(text);
+                                if (isNaN(f)) {
+                                    return;
+                                }
+
+                                offsetSlider.value = f;
+                            }
+                        }
+
+                        Slider {
+                            id: offsetSlider
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: offsetTextField.bottom
+                            from: -15
+                            to: 15
+                            value: algorithmView.offsetDelta
+                            onValueChanged: {
+                                algorithmView.offsetDelta = value;
+                            }
+                        }
+
+                        Text {
+                            id: minText
+                            anchors.left: offsetSlider.left
+                            anchors.top: offsetSlider.bottom
+                            text: offsetSlider.from
+                        }
+
+                        Text {
+                            id: maxText
+                            anchors.right: offsetSlider.right
+                            anchors.top: offsetSlider.bottom
+                            text: offsetSlider.to
+                        }
+                    }
+
+                    Label {
+                        topPadding: 5
+                        text: "Offset Count"
+                    }
+
+                    TextField {
+                        Layout.fillWidth: true
+                        validator: IntValidator {
+                            bottom: 0
+                            top: 1000
+                        }
+                        text: algorithmView.offsetCount
+                        onTextChanged: {
+                            let c = parseInt(text);
+                            if (isNaN(c)) {
+                                return;
+                            }
+                            algorithmView.offsetCount = c;
+                        }
+                    }
+                }
             }
 
-          }
-
-          Slider {
-            id: offsetSlider
-            anchors.top: offsetTextField.bottom
-            from: -15
-            to: 15
-            value: algorithmView.offsetDelta
-            onValueChanged: {
-              algorithmView.offsetDelta = value;
+            CheckBox {
+                Layout.fillWidth: true
+                text: "Show Vertexes"
+                checked: algorithmView.showVertexes
+                onCheckedChanged: {
+                    algorithmView.showVertexes = checked;
+                }
             }
-          }
 
-          Text {
-            id: minText
-            anchors.left: offsetSlider.left
-            anchors.top: offsetSlider.bottom
-            text: offsetSlider.from
-          }
-          Text {
-            id: maxText
-            anchors.right: offsetSlider.right
-            anchors.top: offsetSlider.bottom
-            text: offsetSlider.to
-          }
-        }
-
-        Label {
-          topPadding: 5
-          text: "Offset Count"
-        }
-
-        TextField {
-          validator: IntValidator { bottom: 0; top: 1000 }
-          text: algorithmView.offsetCount
-          onTextChanged: {
-            let c = parseInt(text);
-            if (isNaN(c)) {
-              return;
+            Item {
+                Layout.fillHeight: true
             }
-            algorithmView.offsetCount = c;
-          }
         }
-
-      }
-
     }
-
-    CheckBox {
-      text: "Show Vertexes"
-      checked: algorithmView.showVertexes
-      onCheckedChanged: {
-        algorithmView.showVertexes = checked;
-      }
-    }
-
-    Item {
-      Layout.fillHeight: true
-    }
-  }
 }

--- a/interactiveui/PlineOffsetScene.qml
+++ b/interactiveui/PlineOffsetScene.qml
@@ -4,192 +4,230 @@ import QtQuick.Layouts 1.13
 import Polyline 1.0
 
 SplitView {
-  GeometrySceneView {
-    SplitView.fillWidth: true
-    PlineOffsetAlgorithmView {
-      id: algorithmView
-      anchors.fill: parent
-      spatialIndexTarget: spatialIndexTargetComboBox.currentIndex
-      selfIntersectsTarget: selfIntersectsTargetComboBox.currentIndex
-      finishedPolyline: finishedPlinesComboBox.currentIndex
+    GeometrySceneView {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        SplitView.minimumWidth: 320
+
+        PlineOffsetAlgorithmView {
+            id: algorithmView
+            anchors.fill: parent
+            spatialIndexTarget: spatialIndexTargetComboBox.currentIndex
+            selfIntersectsTarget: selfIntersectsTargetComboBox.currentIndex
+            finishedPolyline: finishedPlinesComboBox.currentIndex
+        }
     }
-  }
 
-  ColumnLayout {
-    anchors.topMargin: 5
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    SplitView.preferredWidth: 300
+    ScrollView {
+        id: controlPanel
+        clip: true
+        contentWidth: availableWidth
+        SplitView.minimumWidth: 270
+        SplitView.preferredWidth: 320
+        SplitView.maximumWidth: 440
+        SplitView.fillHeight: true
 
-    GroupBox {
-      title: "Offset"
-      leftInset: 5
-      ColumnLayout {
-        Item {
-          id: offsetItem
-          implicitWidth: offsetSlider.implicitWidth
-          implicitHeight: offsetTextField.implicitHeight + offsetSlider.implicitHeight + minText.implicitHeight
-          TextField {
-            id: offsetTextField
-            anchors.top: offsetItem.top
-            validator: DoubleValidator { bottom: offsetSlider.from; top: offsetSlider.to }
-            text: if (!focus) { offsetSlider.value } else ""
-            onTextChanged: {
-              let f = parseFloat(text);
-              if (isNaN(f)) {
-                return;
-              }
+        ColumnLayout {
+            width: controlPanel.availableWidth
+            spacing: 8
 
-              offsetSlider.value = f;
+            GroupBox {
+                title: "Offset"
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    anchors.fill: parent
+
+                    Item {
+                        id: offsetItem
+                        Layout.fillWidth: true
+                        implicitHeight: offsetTextField.implicitHeight + offsetSlider.implicitHeight + minText.implicitHeight
+
+                        TextField {
+                            id: offsetTextField
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            validator: DoubleValidator {
+                                bottom: offsetSlider.from
+                                top: offsetSlider.to
+                            }
+                            text: if (!focus) {
+                                offsetSlider.value;
+                            } else
+                                ""
+                            onTextChanged: {
+                                let f = parseFloat(text);
+                                if (isNaN(f)) {
+                                    return;
+                                }
+
+                                offsetSlider.value = f;
+                            }
+                        }
+
+                        Slider {
+                            id: offsetSlider
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.top: offsetTextField.bottom
+                            from: -40
+                            to: 40
+                            value: algorithmView.plineOffset
+                            onValueChanged: {
+                                algorithmView.plineOffset = value;
+                            }
+                        }
+
+                        Text {
+                            id: minText
+                            anchors.left: offsetSlider.left
+                            anchors.top: offsetSlider.bottom
+                            text: offsetSlider.from
+                        }
+
+                        Text {
+                            id: maxText
+                            anchors.right: offsetSlider.right
+                            anchors.top: offsetSlider.bottom
+                            text: offsetSlider.to
+                        }
+                    }
+
+                    Label {
+                        topPadding: 5
+                        text: "Offset Count"
+                    }
+
+                    TextField {
+                        Layout.fillWidth: true
+                        validator: IntValidator {
+                            bottom: 0
+                            top: 1000
+                        }
+                        text: algorithmView.offsetCount
+                        onTextChanged: {
+                            let c = parseInt(text);
+                            if (isNaN(c)) {
+                                return;
+                            }
+                            algorithmView.offsetCount = c;
+                        }
+                    }
+
+                    CheckBox {
+                        Layout.fillWidth: true
+                        text: "Show Last Pruned Raw Offsets"
+                        checked: algorithmView.showLastPrunedRawOffsets
+                        onCheckedChanged: {
+                            algorithmView.showLastPrunedRawOffsets = checked;
+                        }
+                    }
+                }
             }
 
-          }
-
-          Slider {
-            id: offsetSlider
-            anchors.top: offsetTextField.bottom
-            from: -40
-            to: 40
-            value: algorithmView.plineOffset
-            onValueChanged: {
-              algorithmView.plineOffset = value;
+            CheckBox {
+                Layout.fillWidth: true
+                text: "Show Original Polyline Vertexes"
+                checked: algorithmView.showOrigPlineVertexes
+                onCheckedChanged: {
+                    algorithmView.showOrigPlineVertexes = checked;
+                }
             }
-          }
 
-          Text {
-            id: minText
-            anchors.left: offsetSlider.left
-            anchors.top: offsetSlider.bottom
-            text: offsetSlider.from
-          }
-          Text {
-            id: maxText
-            anchors.right: offsetSlider.right
-            anchors.top: offsetSlider.bottom
-            text: offsetSlider.to
-          }
-        }
+            GroupBox {
+                title: "Raw Offsets"
+                Layout.fillWidth: true
 
-        Label {
-          topPadding: 5
-          text: "Offset Count"
-        }
+                ColumnLayout {
+                    anchors.fill: parent
 
-        TextField {
-          validator: IntValidator { bottom: 0; top: 1000 }
-          text: algorithmView.offsetCount
-          onTextChanged: {
-            let c = parseInt(text);
-            if (isNaN(c)) {
-              return;
+                    CheckBox {
+                        id: showRawOffsetCheckBox
+                        Layout.fillWidth: true
+                        text: "Show Raw Offset Polyline"
+                        checked: algorithmView.showRawOffsetPolyline
+                        onCheckedChanged: {
+                            algorithmView.showRawOffsetPolyline = checked;
+                        }
+                    }
+
+                    CheckBox {
+                        Layout.fillWidth: true
+                        enabled: showRawOffsetCheckBox.checked
+                        text: "Show Dual Raw Offset Polyline"
+                        checked: algorithmView.showDualRawOffsetPolyline
+                        onCheckedChanged: {
+                            algorithmView.showDualRawOffsetPolyline = checked;
+                        }
+                    }
+
+                    CheckBox {
+                        Layout.fillWidth: true
+                        enabled: showRawOffsetCheckBox.checked
+                        text: "Show Raw Offset Polyline Vertexes"
+                        checked: algorithmView.showRawOffsetPlineVertexes
+                        onCheckedChanged: {
+                            algorithmView.showRawOffsetPlineVertexes = checked;
+                        }
+                    }
+
+                    CheckBox {
+                        Layout.fillWidth: true
+                        text: "Show Raw Offset Segments"
+                        checked: algorithmView.showRawOffsetSegments
+                        onCheckedChanged: {
+                            algorithmView.showRawOffsetSegments = checked;
+                        }
+                    }
+                }
             }
-            algorithmView.offsetCount = c;
-          }
+
+            GroupBox {
+                title: "Self Intersects"
+                Layout.fillWidth: true
+
+                ComboBox {
+                    id: selfIntersectsTargetComboBox
+                    width: parent.width
+                    model: ["None", "Original Polyline", "Raw Offset Polyline"]
+                }
+            }
+
+            GroupBox {
+                title: "Finished Polylines"
+                Layout.fillWidth: true
+
+                ComboBox {
+                    id: finishedPlinesComboBox
+                    width: parent.width
+                    model: ["None", "Slices", "DualSlices", "Joined"]
+                }
+            }
+
+            GroupBox {
+                title: "Spatial Index"
+                Layout.fillWidth: true
+
+                ComboBox {
+                    id: spatialIndexTargetComboBox
+                    width: parent.width
+                    model: ["None", "Original Polyline", "Raw Offset Polyline"]
+                }
+            }
+
+            CheckBox {
+                Layout.fillWidth: true
+                text: "Show End Intersect Circles"
+                checked: algorithmView.showEndPointIntersectCircles
+                onCheckedChanged: {
+                    algorithmView.showEndPointIntersectCircles = checked;
+                }
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
         }
-
-        CheckBox {
-          text: "Show Last Pruned Raw Offsets"
-          checked: algorithmView.showLastPrunedRawOffsets
-          onCheckedChanged: {
-            algorithmView.showLastPrunedRawOffsets = checked;
-          }
-        }
-      }
-
     }
-
-    CheckBox {
-      text: "Show Original Polyline Vertexes"
-      checked: algorithmView.showOrigPlineVertexes
-      onCheckedChanged: {
-        algorithmView.showOrigPlineVertexes = checked;
-      }
-    }
-
-    GroupBox {
-      title: "Raw Offsets"
-      leftInset: 5
-      ColumnLayout {
-        CheckBox {
-          id: showRawOffsetCheckBox
-          text: "Show Raw Offset Polyline"
-          checked: algorithmView.showRawOffsetPolyline
-          onCheckedChanged: {
-            algorithmView.showRawOffsetPolyline = checked;
-          }
-        }
-
-        CheckBox {
-          enabled: showRawOffsetCheckBox.checked
-          text: "Show Dual Raw Offset Polyline"
-          checked: algorithmView.showDualRawOffsetPolyline
-          onCheckedChanged: {
-            algorithmView.showDualRawOffsetPolyline = checked;
-          }
-        }
-
-        CheckBox {
-          enabled: showRawOffsetCheckBox.checked
-          text: "Show Raw Offset Polyline Vertexes"
-          checked: algorithmView.showRawOffsetPlineVertexes
-          onCheckedChanged: {
-            algorithmView.showRawOffsetPlineVertexes = checked;
-          }
-        }
-
-        CheckBox {
-          text: "Show Raw Offset Segments"
-          checked: algorithmView.showRawOffsetSegments
-          onCheckedChanged: {
-            algorithmView.showRawOffsetSegments = checked;
-          }
-        }
-
-      }
-    }
-
-    GroupBox {
-      title: "Self Intersects"
-      leftInset: 5
-      ComboBox {
-        id: selfIntersectsTargetComboBox
-        leftInset: 5
-        model: ["None", "Original Polyline", "Raw Offset Polyline"]
-        implicitWidth: 200
-      }
-    }
-
-    GroupBox {
-      title: "Finished Polylines"
-      leftInset: 5
-      ComboBox {
-        id: finishedPlinesComboBox
-        leftInset: 5
-        model: ["None", "Slices", "DualSlices", "Joined"]
-      }
-    }
-
-    GroupBox {
-      title: "Spatial Index"
-      leftInset: 5
-      ComboBox {
-        id: spatialIndexTargetComboBox
-        leftInset: 5
-        model: ["None", "Original Polyline", "Raw Offset Polyline"]
-        implicitWidth: 200
-      }
-    }
-
-    CheckBox {
-      text: "Show End Intersect Circles"
-      checked: algorithmView.showEndPointIntersectCircles
-      onCheckedChanged: {
-        algorithmView.showEndPointIntersectCircles = checked;
-      }
-    }
-
-    Item {
-      Layout.fillHeight: true
-    }
-  }
 }

--- a/interactiveui/geometrycanvasitem.cpp
+++ b/interactiveui/geometrycanvasitem.cpp
@@ -16,12 +16,22 @@ void GeometryCanvasItem::updateCoordMatrices(qreal width, qreal height) {
   m_uiToRealCoord = m_realToUICoord.inverted();
 }
 
+// QQuickItem renamed geometryChanged -> geometryChange in Qt 6.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void GeometryCanvasItem::geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) {
+  Q_UNUSED(oldGeometry)
+  QQuickItem::geometryChange(newGeometry, oldGeometry);
+  updateCoordMatrices(newGeometry.width(), newGeometry.height());
+  update();
+}
+#else
 void GeometryCanvasItem::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) {
   Q_UNUSED(oldGeometry)
   QQuickItem::geometryChanged(newGeometry, oldGeometry);
   updateCoordMatrices(newGeometry.width(), newGeometry.height());
   update();
 }
+#endif
 
 QPointF GeometryCanvasItem::convertToGlobalUICoord(const cavc::Vector2<double> &pt) {
   return mapToGlobal(m_realToUICoord * QPointF(pt.x(), pt.y()));

--- a/interactiveui/geometrycanvasitem.h
+++ b/interactiveui/geometrycanvasitem.h
@@ -4,6 +4,7 @@
 #include "cavc/polyline.hpp"
 #include <QMatrix4x4>
 #include <QQuickItem>
+#include <QtGlobal>
 
 /// Base class for setting up interactive geometry views.
 class GeometryCanvasItem : public QQuickItem {
@@ -19,7 +20,11 @@ protected:
   QMatrix4x4 m_realToUICoord;
   QMatrix4x4 m_uiToRealCoord;
   void updateCoordMatrices(qreal width, qreal height);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+#else
   void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+#endif
   QPointF convertToGlobalUICoord(const cavc::Vector2<double> &pt);
   std::size_t vertexUnderPosition(QPointF uiGlobalPos, const cavc::Polyline<double> &pline);
 };

--- a/interactiveui/main.cpp
+++ b/interactiveui/main.cpp
@@ -21,7 +21,9 @@ int main(int argc, char *argv[]) {
   qmlRegisterType<PlineCombineAlgorithmView>("Polyline", 1, 0, "PlineCombineAlgorithmView");
   qmlRegisterType<PlineOffsetIslandsAlgorithmView>("Polyline", 1, 0, "PlineOffsetIslandsAlgorithmView");
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 
   QGuiApplication app(argc, argv);
   QFont defaultFont(app.font().family(), 12);

--- a/interactiveui/main.qml
+++ b/interactiveui/main.qml
@@ -4,46 +4,50 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
 ApplicationWindow {
-  id: mainWindow
-  visible: true
-  width: 1680
-  height: 1050
-  title: qsTr("Cavalier Contours")
-  header:  TabBar {
-    id: tabBar
-    TabButton {
-      text: "Polyline Offset"
-    }
-    TabButton {
-      text: "Polyline Combine"
-    }
-    TabButton {
-      text: "Polyline Offset Islands"
-    }
-    TabButton {
-      text: "Hilbert Curve"
-    }
-  }
+    id: mainWindow
+    visible: true
+    width: 1680
+    height: 1050
+    minimumWidth: 1024
+    minimumHeight: 680
+    title: qsTr("Cavalier Contours")
 
-  Page {
-    anchors.fill: parent
+    header: TabBar {
+        id: tabBar
+        width: parent.width
+
+        TabButton {
+            width: tabBar.width / 4
+            text: "Polyline Offset"
+        }
+        TabButton {
+            width: tabBar.width / 4
+            text: "Polyline Combine"
+        }
+        TabButton {
+            width: tabBar.width / 4
+            text: "Polyline Offset Islands"
+        }
+        TabButton {
+            width: tabBar.width / 4
+            text: "Hilbert Curve"
+        }
+    }
+
     Rectangle {
-      anchors.fill: parent
-      border.width: 2
-      border.color: "grey"
-      StackLayout {
         anchors.fill: parent
-        anchors.margins: 2
-        currentIndex: tabBar.currentIndex
+        border.width: 2
+        border.color: "grey"
 
-        PlineOffsetScene {}
-        PlineCombineScene {}
-        PlineOffsetIslandsScene {}
-        HilbertCurveScene {}
-      }
+        StackLayout {
+            anchors.fill: parent
+            anchors.margins: 2
+            currentIndex: tabBar.currentIndex
 
+            PlineOffsetScene {}
+            PlineCombineScene {}
+            PlineOffsetIslandsScene {}
+            HilbertCurveScene {}
+        }
     }
-
-  }
-
 }

--- a/interactiveui/simplecirclenode.cpp
+++ b/interactiveui/simplecirclenode.cpp
@@ -5,7 +5,9 @@ SimpleCircleNode::SimpleCircleNode() : FlatColorGeometryNode(true) {
   m_xPos = 0;
   m_yPos = 0;
   m_radius = 1;
-  m_geometry.setDrawingMode(QSGGeometry::DrawTriangleFan);
+  // Draw vertex markers as hollow squares for stable rendering across backends.
+  m_geometry.setDrawingMode(QSGGeometry::DrawLineStrip);
+  m_geometry.setLineWidth(1.5f);
 }
 
 void SimpleCircleNode::setGeometry(qreal x, qreal y, qreal radius) {
@@ -16,8 +18,8 @@ void SimpleCircleNode::setGeometry(qreal x, qreal y, qreal radius) {
 }
 
 void SimpleCircleNode::updateGeometry() {
-  int surroundingVertexes = 12;
-  int vertexCount = surroundingVertexes + 2;
+  // 5 points (first repeated) to close the square with DrawLineStrip.
+  int vertexCount = 5;
 
   m_geometry.allocate(vertexCount, vertexCount);
   std::uint32_t *segVertexIndices = m_geometry.indexDataAsUInt();
@@ -26,12 +28,11 @@ void SimpleCircleNode::updateGeometry() {
   }
 
   QSGGeometry::Point2D *vertexData = m_geometry.vertexDataAsPoint2D();
-  vertexData[0].set(m_xPos, m_yPos);
-  for (int i = 1; i < vertexCount; ++i) {
-    double angle = cavc::utils::tau<double>() * static_cast<double>(i - 1) /
-                   static_cast<double>(surroundingVertexes);
-    vertexData[i].set(m_xPos + m_radius * std::cos(angle), m_yPos + m_radius * std::sin(angle));
-  }
+  vertexData[0].set(m_xPos - m_radius, m_yPos - m_radius);
+  vertexData[1].set(m_xPos + m_radius, m_yPos - m_radius);
+  vertexData[2].set(m_xPos + m_radius, m_yPos + m_radius);
+  vertexData[3].set(m_xPos - m_radius, m_yPos + m_radius);
+  vertexData[4].set(m_xPos - m_radius, m_yPos - m_radius);
 
   markDirty(QSGNode::DirtyGeometry);
 }


### PR DESCRIPTION
## Summary
- Migrate project UI/build usage to Qt6 and refactor QML layouts for responsive behavior.
- Fix vertex marker rendering style in the scene graph.
- Update CavalierContours submodule to 31a012947aa2e7e9474e2ec90502825afe8b99a4.
- Qt5 support has ended per official Qt release/support policy, so this PR upgrades to Qt6.

## Why Qt6
- Official Qt release/support table shows Qt 5.15 LTS standard support ended:
  - 2023-05-26 for Qt Legacy licenses
  - 2025-05-26 for Qt Subscription license holders
- Source: https://doc.qt.io/qt-6.9/qt-releases.html

## Commit Structure
- d436ec8: update to qt 6 (UI refactor and Qt6 compatibility updates)
- be4d38e: chore: update CavalierContours submodule to 31a0129

## Validation
- Built successfully with: cmake --build --preset win_msvc_release
